### PR TITLE
Disabled countingBrackets to fix false positive errors with default examples in Playground 

### DIFF
--- a/lib/src/wip/getErrorsMap.dart
+++ b/lib/src/wip/getErrorsMap.dart
@@ -5,7 +5,6 @@ import 'package:highlight/languages/java.dart';
 import 'package:highlight/languages/python.dart';
 import 'package:highlight/languages/scala.dart';
 
-import 'language_syntax/brackets_counting.dart';
 import 'language_syntax/golang_syntax.dart';
 import 'language_syntax/java_dart_syntax.dart';
 import 'language_syntax/python_syntax.dart';
@@ -13,7 +12,10 @@ import 'language_syntax/scala_syntax.dart';
 
 Map<int, String> getErrorsMap(String text, Mode? language) {
   Map<int, String> errors = {};
-  errors.addAll(countingBrackets(text));
+
+  /// This check is temporarily disabled because unclosed ' and "
+  /// characters in comments cause false positive errors
+  // errors.addAll(countingBrackets(text));
 
   if (language == java || language == dart) {
     errors.addAll(findJavaDartErrors(text));

--- a/lib/src/wip/getErrorsMap.dart
+++ b/lib/src/wip/getErrorsMap.dart
@@ -5,6 +5,7 @@ import 'package:highlight/languages/java.dart';
 import 'package:highlight/languages/python.dart';
 import 'package:highlight/languages/scala.dart';
 
+// import 'language_syntax/brackets_counting.dart';
 import 'language_syntax/golang_syntax.dart';
 import 'language_syntax/java_dart_syntax.dart';
 import 'language_syntax/python_syntax.dart';

--- a/lib/src/wip/getErrorsMap.dart
+++ b/lib/src/wip/getErrorsMap.dart
@@ -13,8 +13,8 @@ import 'language_syntax/scala_syntax.dart';
 Map<int, String> getErrorsMap(String text, Mode? language) {
   Map<int, String> errors = {};
 
-  /// This check is temporarily disabled because unclosed ' and "
-  /// characters in comments cause false positive errors
+  // This check is temporarily disabled because unclosed ' and "
+  // characters in comments cause false positive errors
   // errors.addAll(countingBrackets(text));
 
   if (language == java || language == dart) {

--- a/lib/src/wip/language_syntax/brackets_counting.dart
+++ b/lib/src/wip/language_syntax/brackets_counting.dart
@@ -16,9 +16,9 @@ Map<int, String> countingBrackets(String text) {
     if (char == "\n") {
       lineNumber++;
       continue;
-    } else if (char == "/" &&
+    } else if ((char == "*" || char == "/" &&
         i < text.length - 1 &&
-        text[i + 1] == char &&
+        text[i + 1] == char) &&
         !isCharInString) {
       while (char != "\n" && i < text.length - 1) {
         i++;

--- a/lib/src/wip/language_syntax/brackets_counting.dart
+++ b/lib/src/wip/language_syntax/brackets_counting.dart
@@ -16,10 +16,12 @@ Map<int, String> countingBrackets(String text) {
     if (char == "\n") {
       lineNumber++;
       continue;
+      // TODO: discern multiplication & other uses of "*" from comments
     } else if ((char == "*" || char == "/" &&
         i < text.length - 1 &&
         text[i + 1] == char) &&
         !isCharInString) {
+      // skip comments
       while (char != "\n" && i < text.length - 1) {
         i++;
         char = text[i];

--- a/lib/src/wip/language_syntax/brackets_counting.dart
+++ b/lib/src/wip/language_syntax/brackets_counting.dart
@@ -16,12 +16,10 @@ Map<int, String> countingBrackets(String text) {
     if (char == "\n") {
       lineNumber++;
       continue;
-      // TODO: discern multiplication & other uses of "*" from comments
-    } else if ((char == "*" || char == "/" &&
+    } else if (char == "/" &&
         i < text.length - 1 &&
-        text[i + 1] == char) &&
+        text[i + 1] == char &&
         !isCharInString) {
-      // skip comments
       while (char != "\n" && i < text.length - 1) {
         i++;
         char = text[i];


### PR DESCRIPTION
The reason for the false positive errors is ' and " characters in words in multi-line comments

#17 