### PR TITLE
Draft: Add line wrapping support

### DIFF
--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -353,14 +353,14 @@ class _CodeFieldState extends State<CodeField> {
           if (widget.wrap) {
             // get wrapped line count in each paragraph
             const textFieldPadding =
-                paddingLeft + 3; // TODO: not sure why the 3 is needed!
+                paddingLeft + 3; // TODO(emuell): not sure why the 3 is needed!
             final codeFieldWidth = constraints.maxWidth.floorToDouble() -
                 gutterStyle.totalWidth() -
                 textFieldPadding;
             linesInParagraps = [];
             for (var i = 0; i < codeLines.length; ++i) {
               final codeLine = codeLines[i];
-              // codelines contain an extra newline at the end, except for the last line
+              // codelines contain an extra newline, except for the last line
               final text = (i == codeLines.length - 1)
                   ? codeLine.text
                   : codeLine.text.replaceAll('\n', '');

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -345,7 +345,6 @@ class _CodeFieldState extends State<CodeField> {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-
         Widget? gutter;
         if (gutterStyle.showGutter) {
           final List<int> linesInParagraps;
@@ -417,10 +416,10 @@ class _CodeFieldState extends State<CodeField> {
                 return codeField;
               } else {
                 return _wrapInScrollView(
-                      codeField,
-                      textStyle,
-                      constraints.maxWidth,
-                    );
+                  codeField,
+                  textStyle,
+                  constraints.maxWidth,
+                );
               }
             },
           ),

--- a/lib/src/gutter/gutter.dart
+++ b/lib/src/gutter/gutter.dart
@@ -115,7 +115,6 @@ class GutterWidget extends StatelessWidget {
     );
   }
 
-
   void _fillIssues(List<_GutterRowBuilder> tableRowBuilders) {
     for (final issue in codeController.issues) {
       final row = tableRowBuilders.firstWhereOrNull(

--- a/lib/src/line_numbers/gutter_style.dart
+++ b/lib/src/line_numbers/gutter_style.dart
@@ -75,6 +75,25 @@ class GutterStyle {
         showFoldingHandles: showFoldingHandles,
         showLineNumbers: showLineNumbers,
       );
+
+  // internally used sizes
+  static const _errorColumnWidth = 16.0;
+  static const _foldingColumnWidth = 16.0;
+
+  // applied width, depending on showError and showFoldingHandles states
+  double totalWidth() {
+    return (width - _errorColumnWidth - _foldingColumnWidth) +
+        errorColumnWidth() +
+        foldingColumnWidth();
+  }
+
+  double errorColumnWidth() {
+    return showErrors ? _errorColumnWidth : 0.0;
+  }
+
+  double foldingColumnWidth() {
+    return showFoldingHandles ? _foldingColumnWidth : 0.0;
+  }
 }
 
 @Deprecated('Renamed to GutterStyle')


### PR DESCRIPTION
This implements the missing "wrap" option in CodeField.

Changes:
- only put code fields into a horizontal scrollview when wrapping is disabled
- calculate line wrap count for each paragraph with a TextPainter when building the CodeField layout, and pass it over to the Gutter so it can skip displaying line numbers for wrapped lines

The second task is tricky. In order to adjust the Gutter correctly, the actual text editor's width needs to be fetched via a LayoutBuilder. Then each line must be rendered in order to compute line metrics. This unfortunately is done for all text lines, so this will get slow with large texts. I also had to substract 3 magic pixels from the width while computing the line metrics, in order to fit the computed vs real drawn output. Not sure where this difference comes from, but it doesn't seem to be affected by the used font or font size.

This does the job for my project, but there might be a better way to do all this. So feel free to merge, ignore, or use this as an inspiration :)

PS: if this isn't merged then the wrap option should be removed from CodeField to avoid confusion, as it right now does nothing.




  