### PR TITLE
Upgraded pub packages for Flutter v3.13.6

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - run: flutter --version
 
+      - run: flutter clean
+
       - name: Install Dependencies
         run: flutter pub get
 

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -34,6 +34,8 @@ jobs:
       - name: Install Dependencies
         run: flutter pub get
 
+      - run: flutter pub outdated
+
       - name: Analyze
         run: dart analyze --fatal-infos
 

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ '**' ]
 
 env:
-  flutter_version: 3.10.2
+  flutter_version: 3.13.6
 
 jobs:
   build:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,18 +5,18 @@ version: 1.0.0+1
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
-  flutter: '>=3.0.0'
+  flutter: ">=3.13.6"
 
 dependencies:
   flutter: { sdk: flutter }
   flutter_code_editor: { path: ../ }
   flutter_highlight: ^0.7.0
   highlight: ^0.7.0
-  http: ^0.13.5
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test: { sdk: flutter }
-  total_lints: ^2.17.4
+  total_lints: ^3.1.1
 
 flutter:
   uses-material-design: true

--- a/lib/src/search/controller.dart
+++ b/lib/src/search/controller.dart
@@ -73,7 +73,7 @@ class CodeSearchController extends ChangeNotifier {
     patternFocusNode.unfocus();
     _hidingTimer?.cancel();
 
-    if (returnFocusToCodeField == true) {
+    if (returnFocusToCodeField) {
       _codeFieldFocusNode?.requestFocus();
     }
 
@@ -160,8 +160,8 @@ class CodeSearchController extends ChangeNotifier {
       return;
     }
 
-    final shouldDismiss = patternFocusNode.hasFocus == false &&
-        _codeFieldFocusNode?.hasFocus == false;
+    final shouldDismiss =
+        !patternFocusNode.hasFocus && _codeFieldFocusNode?.hasFocus == false;
 
     if (shouldDismiss) {
       hideSearch(returnFocusToCodeField: false);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,15 +11,15 @@ dependencies:
   autotrie: ^2.0.0
   characters: ^1.2.1
   charcode: ^1.3.1
-  collection: ^1.16.0
+  collection: ^1.18.0
   equatable: ^2.0.5
   flutter: { sdk: flutter }
   flutter_highlight: ^0.7.0
   highlight: ^0.7.0
-  http: ^0.13.5
+  http: ^1.1.0
   linked_scroll_controller: ^0.2.0
-  meta: ^1.7.0
-  mocktail: ^0.3.0
+  meta: ^1.11.0
+  mocktail: ^1.0.1
   scrollable_positioned_list: ^0.3.5
   tuple: ^2.0.1
   url_launcher: ^6.1.8
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   fake_async: ^1.3.1
   flutter_test: { sdk: flutter }
-  total_lints: ^2.18.0
+  total_lints: ^3.1.1
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   autotrie: ^2.0.0
   characters: ^1.2.1
   charcode: ^1.3.1
-  collection: ^1.18.0
+  collection: ^1.17.2
   equatable: ^2.0.5
   flutter: { sdk: flutter }
   flutter_highlight: ^0.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   highlight: ^0.7.0
   http: ^1.1.0
   linked_scroll_controller: ^0.2.0
-  meta: ^1.11.0
+  meta: ^1.9.1
   mocktail: ^1.0.1
   scrollable_positioned_list: ^0.3.5
   tuple: ^2.0.1

--- a/test/src/code/string_get_changed_range_test.dart
+++ b/test/src/code/string_get_changed_range_test.dart
@@ -82,7 +82,7 @@ void main() {
         str1: 'abccde',
         str2: 'abcde',
         expected: [TextRange(start: 2, end: 2), TextRange(start: 3, end: 3)],
-      )
+      ),
     ];
     const affinities = [TextAffinity.upstream, TextAffinity.downstream];
 

--- a/test/src/folding/parsers/highlight_parser_go_test.dart
+++ b/test/src/folding/parsers/highlight_parser_go_test.dart
@@ -58,7 +58,7 @@ func (
         InvalidFoldableBlock(endLine: 6, type: FBT.braces),
         InvalidFoldableBlock(endLine: 6, type: FBT.braces),
         InvalidFoldableBlock(startLine: 6, type: FBT.parentheses),
-        InvalidFoldableBlock(endLine: 8, type: FBT.braces)
+        InvalidFoldableBlock(endLine: 8, type: FBT.braces),
       ];
       _Tester.parseAndCheck(
         mode: go,

--- a/test/src/folding/parsers/indent_parser_test.dart
+++ b/test/src/folding/parsers/indent_parser_test.dart
@@ -169,7 +169,7 @@ numbers = [1,
     5
 ]''',
           expected: [_FB(firstLine: 0, lastLine: 4, type: _T.indent)],
-        )
+        ),
       ];
 
       for (final example in examples) {

--- a/test/src/history/code_history_controller_test.dart
+++ b/test/src/history/code_history_controller_test.dart
@@ -76,8 +76,14 @@ void main() {
           final controller = await pumpController(wt, MethodSnippet.full);
           await wt.cursorEnd();
 
+          controller.value = controller.value.replacedText(
+            controller.value.text,
+          );
           controller.value = controller.value.typed('a');
           controller.value = controller.value.typed('b');
+          controller.value = controller.value.replacedText(
+            controller.value.text,
+          );
           controller.foldAt(0);
           controller.unfoldAt(0);
 

--- a/test/src/history/code_history_controller_test.dart
+++ b/test/src/history/code_history_controller_test.dart
@@ -76,10 +76,8 @@ void main() {
           final controller = await pumpController(wt, MethodSnippet.full);
           await wt.cursorEnd();
 
-          controller.value = controller.value;
           controller.value = controller.value.typed('a');
           controller.value = controller.value.typed('b');
-          controller.value = controller.value;
           controller.foldAt(0);
           controller.unfoldAt(0);
 


### PR DESCRIPTION
```
flutter pub outdated:
Showing outdated packages.
[*] indicates versions that are not the latest available.

Package Name  Current  Upgradable  Resolvable  Latest  

direct dependencies: all up-to-date.

dev_dependencies: all up-to-date.
all dependencies are up-to-date.
```

```
flutter test:
00:31 +271: All tests passed!
```

```
flutter doctor:
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.13.6, on macOS 14.0 23A344 darwin-x64, locale en-KZ)
[✓] Android toolchain - develop for Android devices (Android SDK version 33.0.2)
[✓] Xcode - develop for iOS and macOS (Xcode 15.0)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2022.1)
[✓] VS Code (version 1.83.0)
[✓] Connected device (2 available)
[✓] Network resources

• No issues found!
```

`example/lib/02.code_field % flutter run:`
<img width="629" alt="Screenshot 2023-10-11 at 19 25 34" src="https://github.com/akvelon/flutter-code-editor/assets/31556582/ff046e4f-87f5-45ae-a0f9-3ff9b9016d66">