### PR TITLE
Disable smart quotes and smart dashes on iOS

### DIFF
--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -139,6 +139,12 @@ class CodeField extends StatefulWidget {
   /// {@macro flutter.widgets.textField.textStyle}
   final TextStyle? textStyle;
 
+  /// {@macro flutter.widgets.textField.smartDashesType}
+  final SmartDashesType smartDashesType;
+
+  /// {@macro flutter.widgets.textField.smartQuotesType}
+  final SmartQuotesType smartQuotesType;
+
   /// A way to replace specific line numbers by a custom TextSpan
   final TextSpan Function(int, TextStyle?)? lineNumberBuilder;
 
@@ -175,6 +181,8 @@ class CodeField extends StatefulWidget {
     this.background,
     this.decoration,
     this.textStyle,
+    this.smartDashesType = SmartDashesType.disabled,
+    this.smartQuotesType = SmartQuotesType.disabled,
     this.padding = EdgeInsets.zero,
     GutterStyle? gutterStyle,
     this.enabled,
@@ -400,6 +408,8 @@ class _CodeFieldState extends State<CodeField> {
       focusNode: _focusNode,
       scrollPadding: widget.padding,
       style: textStyle,
+      smartDashesType: widget.smartDashesType,
+      smartQuotesType: widget.smartQuotesType,
       controller: widget.controller,
       minLines: widget.minLines,
       maxLines: widget.maxLines,


### PR DESCRIPTION
Expose [`smartDashesType`][1] and [`smartQuotesType`][2] on the underlying `TextField`, and disable them by default.

This fixes an issue where typing a `"` on the iOS keyboard would automatically be replaced by a `“`.

[1]: https://api.flutter.dev/flutter/material/TextField/smartDashesType.html
[2]: https://api.flutter.dev/flutter/material/TextField/smartQuotesType.html