### PR TITLE
Fix issue 286: Line numbers do not align with lines

### DIFF
--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -406,6 +406,7 @@ class _CodeFieldState extends State<CodeField> {
     final defaultTextStyle = TextStyle(
       color: styles?[rootKey]?.color ?? DefaultStyles.textColor,
       fontSize: themeData.textTheme.titleMedium?.fontSize,
+      height: themeData.textTheme.titleMedium?.height,
     );
 
     textStyle = defaultTextStyle.merge(widget.textStyle);


### PR DESCRIPTION
## What type of PR is this?
- 🐛 Bug Fix

## Description

After reviewing this issue #286 I discovered that the solution to the problem was to add a default _height_ to **defaultTextStyle**. In this case, the default _height_ comes from the **themeData** itself.

With this change, no workaround would be necessary.

## Added tests?
- 🙅 no, because they aren't needed

## Added to documentation?
- 🙅 No documentation needed
