### PR TITLE
fix unchecked dispose issues

### DIFF
--- a/lib/src/code_field/code_controller.dart
+++ b/lib/src/code_field/code_controller.dart
@@ -125,6 +125,8 @@ class CodeController extends TextEditingController {
   @visibleForTesting
   TextSpan? lastTextSpan;
 
+  bool _disposed = false;
+
   late final actions = <Type, Action<Intent>>{
     CommentUncommentIntent: CommentUncommentAction(controller: this),
     CopySelectionTextIntent: CopyAction(controller: this),
@@ -230,6 +232,10 @@ class CodeController extends TextEditingController {
     if (_code.text != codeSentToAnalysis.text) {
       // If the code has been changed before we got analysis result, discard it.
       // This happens on request race condition.
+      return;
+    }
+
+    if (_disposed) {
       return;
     }
 
@@ -971,6 +977,7 @@ class CodeController extends TextEditingController {
 
   @override
   void dispose() {
+    _disposed = true;
     _debounce?.cancel();
     historyController.dispose();
     searchController.dispose();

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -261,6 +261,9 @@ class _CodeFieldState extends State<CodeField> {
     disableSpellCheckIfWeb();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if(!mounted){
+        return;
+      }
       final double width = _codeFieldKey.currentContext!.size!.width;
       final double height = _codeFieldKey.currentContext!.size!.height;
       windowSize = Size(width, height);
@@ -312,6 +315,9 @@ class _CodeFieldState extends State<CodeField> {
   void rebuild() {
     setState(() {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if(!mounted){
+          return;
+        }
         // For some reason _codeFieldKey.currentContext is null in tests
         // so check first.
         final context = _codeFieldKey.currentContext;


### PR DESCRIPTION
## What type of PR is this?

- 🐛 Bug Fix

## Description

The current implementation accesses context and listeners that must not be accessed if already disposed. These cases may happen (as they did for me) and should be handled gracefully. This pull requests will solve this.

## Added tests?

- 🙅 no, because they aren't needed

## Added to documentation?

- 🙅 No documentation needed
