### PR TITLE
Fix line numbers not aligning with lines

### DIFF
--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -506,6 +506,7 @@ class _CodeFieldState extends State<CodeField> {
     return GutterWidget(
       codeController: widget.controller,
       style: gutterStyle,
+      scrollController: _numberScroll,
     );
   }
 

--- a/lib/src/gutter/gutter.dart
+++ b/lib/src/gutter/gutter.dart
@@ -19,16 +19,24 @@ class GutterWidget extends StatelessWidget {
   const GutterWidget({
     required this.codeController,
     required this.style,
+    required this.scrollController,
   });
 
   final CodeController codeController;
   final GutterStyle style;
+  final ScrollController? scrollController;
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: codeController,
-      builder: _buildOnChange,
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: SingleChildScrollView(
+        controller: scrollController,
+        child: AnimatedBuilder(
+          animation: codeController,
+          builder: _buildOnChange,
+        ),
+      ),
     );
   }
 
@@ -66,7 +74,7 @@ class GutterWidget extends StatelessWidget {
     }
 
     return Container(
-      padding: EdgeInsets.only(top: 16, bottom: 16, right: style.margin),
+      padding: EdgeInsets.only(right: style.margin),
       width: style.showLineNumbers ? gutterWidth : null,
       child: Table(
         columnWidths: {

--- a/lib/src/gutter/gutter.dart
+++ b/lib/src/gutter/gutter.dart
@@ -66,7 +66,7 @@ class GutterWidget extends StatelessWidget {
     }
 
     return Container(
-      padding: EdgeInsets.only(top: 12, bottom: 12, right: style.margin),
+      padding: EdgeInsets.only(top: 16, bottom: 16, right: style.margin),
       width: style.showLineNumbers ? gutterWidth : null,
       child: Table(
         columnWidths: {


### PR DESCRIPTION
## What type of PR is this?

<!-- Remove all that don't apply -->

- 🐛 Bug Fix
## Description
- Fixes https://github.com/akvelon/flutter-code-editor/issues/286
- Fixes https://github.com/akvelon/flutter-code-editor/issues/288
- Fixes https://github.com/akvelon/flutter-code-editor/issues/261
- Fixes https://github.com/akvelon/flutter-code-editor/issues/250

Line numbers now scroll with the code lines
The padding has been fixed so that
- the line numbers align with the code
- the line numbers cut off at the same point as the code while scrolling


`_numberScroll` actually already existed and was setup for the scroll syncing so I assume the functionality was lost along the way
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Added tests?

- 🙅 no, because they aren't needed

## Added to documentation?

- 🙅 No documentation needed
