### PR TITLE
Fix gutter line-number alignment with editor text

### DIFF
--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -234,7 +234,7 @@ class _CodeFieldState extends State<CodeField> {
 
   FocusNode? _focusNode;
   String? lines;
-  String longestLine = '';
+  var longestLine = '';
   Size? windowSize;
   late TextStyle textStyle;
   Color? _backgroundCol;
@@ -390,9 +390,7 @@ class _CodeFieldState extends State<CodeField> {
     );
 
     return SingleChildScrollView(
-      padding: EdgeInsets.only(
-        right: widget.padding.right,
-      ),
+      padding: EdgeInsets.zero,
       scrollDirection: Axis.horizontal,
       controller: _horizontalCodeScroll,
       child: intrinsic,
@@ -421,14 +419,21 @@ class _CodeFieldState extends State<CodeField> {
     );
 
     textStyle = defaultTextStyle.merge(widget.textStyle);
+    final lineStrutStyle = StrutStyle.fromTextStyle(
+      textStyle,
+      forceStrutHeight: true,
+    );
+    final contentPadding = const EdgeInsets.only(left: 8).add(widget.padding);
 
     final codeField = TextField(
       focusNode: _focusNode,
-      scrollPadding: widget.padding,
+      scrollPadding: EdgeInsets.zero,
       style: textStyle,
       smartDashesType: widget.smartDashesType,
       smartQuotesType: widget.smartQuotesType,
       controller: widget.controller,
+      strutStyle: lineStrutStyle,
+      textAlignVertical: TextAlignVertical.top,
       undoController: widget.undoController,
       minLines: widget.minLines,
       maxLines: widget.maxLines,
@@ -436,7 +441,7 @@ class _CodeFieldState extends State<CodeField> {
       scrollController: _codeScroll,
       decoration: const InputDecoration(
         isCollapsed: true,
-        contentPadding: EdgeInsets.symmetric(vertical: 16),
+        contentPadding: EdgeInsets.zero,
         disabledBorder: InputBorder.none,
         border: InputBorder.none,
         focusedBorder: InputBorder.none,
@@ -468,7 +473,7 @@ class _CodeFieldState extends State<CodeField> {
         decoration: widget.decoration,
         color: _backgroundCol,
         key: _codeFieldKey,
-        padding: const EdgeInsets.only(left: 8),
+        padding: contentPadding,
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -490,6 +495,7 @@ class _CodeFieldState extends State<CodeField> {
       color: lineNumberColor,
       fontFamily: textStyle.fontFamily,
       fontSize: lineNumberSize,
+      height: textStyle.height,
     );
 
     final gutterStyle = widget.gutterStyle.copyWith(
@@ -540,7 +546,7 @@ class _CodeFieldState extends State<CodeField> {
   }
 
   double _getCaretHeight(TextPainter textPainter) {
-    final double? caretFullHeight = textPainter.getFullHeightForCaret(
+    final double caretFullHeight = textPainter.getFullHeightForCaret(
       widget.controller.selection.base,
       Rect.zero,
     );
@@ -550,7 +556,6 @@ class _CodeFieldState extends State<CodeField> {
   double _getPopupLeftOffset(TextPainter textPainter) {
     return max(
       _getCaretOffset(textPainter).dx +
-          widget.padding.left -
           _horizontalCodeScroll!.offset +
           (_editorOffset?.dx ?? 0),
       0,
@@ -561,8 +566,6 @@ class _CodeFieldState extends State<CodeField> {
     return max(
       _getCaretOffset(textPainter).dy +
           caretHeight +
-          16 +
-          widget.padding.top -
           _codeScroll!.offset +
           (_editorOffset?.dy ?? 0),
       0,
@@ -603,7 +606,7 @@ class _CodeFieldState extends State<CodeField> {
 
   OverlayEntry _buildSearchOverlay() {
     final colorScheme = Theme.of(context).colorScheme;
-    final borderColor = _getTextColorFromTheme() ?? colorScheme.onBackground;
+    final borderColor = _getTextColorFromTheme() ?? colorScheme.onSurface;
     return OverlayEntry(
       builder: (context) {
         return Positioned(

--- a/lib/src/gutter/gutter.dart
+++ b/lib/src/gutter/gutter.dart
@@ -28,14 +28,11 @@ class GutterWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 16),
-      child: SingleChildScrollView(
-        controller: scrollController,
-        child: AnimatedBuilder(
-          animation: codeController,
-          builder: _buildOnChange,
-        ),
+    return SingleChildScrollView(
+      controller: scrollController,
+      child: AnimatedBuilder(
+        animation: codeController,
+        builder: _buildOnChange,
       ),
     );
   }
@@ -90,6 +87,13 @@ class GutterWidget extends StatelessWidget {
 
   void _fillLineNumbers(List<TableRow> tableRows) {
     final code = codeController.code;
+    final numberStyle = style.textStyle;
+    final numberStrutStyle = numberStyle == null
+        ? null
+        : StrutStyle.fromTextStyle(
+            numberStyle,
+            forceStrutHeight: true,
+          );
 
     for (final i in code.hiddenLineRanges.visibleLineNumbers) {
       final lineIndex = _lineIndexToTableRowIndex(i);
@@ -100,7 +104,8 @@ class GutterWidget extends StatelessWidget {
 
       tableRows[lineIndex].children![_lineNumberColumn] = Text(
         style.showLineNumbers ? '${i + 1}' : ' ',
-        style: style.textStyle,
+        style: numberStyle,
+        strutStyle: numberStrutStyle,
         textAlign: style.textAlign,
       );
     }


### PR DESCRIPTION
Fixes vertical misalignment between gutter line numbers and code text in `CodeField`.

Fixes: #215, #312 

Gutter and editor were using different/duplicated vertical spacing paths, which caused numbers to drift from code lines.

## Changes

- Unified padding so gutter and editor share the same vertical origin.
- Removed duplicated vertical padding paths.
- Kept line-height behavior consistent between code and line numbers.
- Adjusted popup offset calculations to match the new padding model.

## Files changed
- `lib/src/code_field/code_field.dart`
- `lib/src/gutter/gutter.dart`

## Validation
- Checked visually in example app (`03.change_language_theme`).
- Ran:
  - `dart analyze lib/src/code_field/code_field.dart lib/src/gutter/gutter.dart`
  - `flutter test test/src/code_field/code_controller_shortcut_test.dart`